### PR TITLE
Compilation speed optimization

### DIFF
--- a/nao_lola_client/include/nao_lola_client/connection.hpp
+++ b/nao_lola_client/include/nao_lola_client/connection.hpp
@@ -19,7 +19,6 @@
 #include <string>
 #include "boost/asio.hpp"
 #include "rclcpp/logger.hpp"
-#include "rclcpp/rclcpp.hpp"
 
 #define MSGPACK_READ_LENGTH 896
 

--- a/nao_lola_client/include/nao_lola_client/msgpack_parser.hpp
+++ b/nao_lola_client/include/nao_lola_client/msgpack_parser.hpp
@@ -18,7 +18,7 @@
 #include <map>
 #include <string>
 #include <vector>
-#include "msgpack.hpp"
+#include "msgpack/object.hpp"
 #include "nao_lola_sensor_msgs/msg/joint_currents.hpp"
 #include "nao_lola_sensor_msgs/msg/joint_positions.hpp"
 #include "nao_lola_sensor_msgs/msg/joint_stiffnesses.hpp"

--- a/nao_lola_client/include/nao_lola_client/nao_lola_client.hpp
+++ b/nao_lola_client/include/nao_lola_client/nao_lola_client.hpp
@@ -18,7 +18,9 @@
 #include <thread>
 #include <memory>
 #include <mutex>
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
+#include "rclcpp/publisher.hpp"
+#include "rclcpp/subscription.hpp"
 #include "nao_lola_sensor_msgs/msg/joint_positions.hpp"
 #include "nao_lola_sensor_msgs/msg/joint_stiffnesses.hpp"
 #include "nao_lola_sensor_msgs/msg/joint_temperatures.hpp"

--- a/nao_lola_client/src/connection.cpp
+++ b/nao_lola_client/src/connection.cpp
@@ -14,6 +14,9 @@
 
 #include <string>
 #include "nao_lola_client/connection.hpp"
+#include "rclcpp/clock.hpp"
+#include "rclcpp/logging.hpp"
+#include "rclcpp/utilities.hpp"
 
 #define ENDPOINT "/tmp/robocup"
 
@@ -25,9 +28,9 @@ Connection::Connection()
   do {
     socket.connect(ENDPOINT, ec);
     if (ec) {
-      RCLCPP_WARN_SKIPFIRST_THROTTLE(
+      RCLCPP_WARN_STREAM_SKIPFIRST_THROTTLE(
         logger, clock, 1000,
-        (std::string{"Could not connect to LoLA, retrying: "} + ec.message()).c_str());
+        "Could not connect to LoLA, retrying: " << ec.message());
     }
   } while (ec && rclcpp::ok());
 }

--- a/nao_lola_client/src/msgpack_packer.cpp
+++ b/nao_lola_client/src/msgpack_packer.cpp
@@ -18,9 +18,16 @@
 #include <memory>
 #include <vector>
 #include "nao_lola_client/msgpack_packer.hpp"
-#include "msgpack.hpp"
+#include "msgpack/object.hpp"
+#include "msgpack/pack.hpp"
+#include "msgpack/adaptor/bool.hpp"
+#include "msgpack/adaptor/cpp11/array.hpp"
+#include "msgpack/adaptor/float.hpp"
+#include "msgpack/adaptor/map.hpp"
+#include "msgpack/adaptor/string.hpp"
+#include "msgpack/zone.hpp"
 #include "nao_lola_client/command_index_conversion.hpp"
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/logging.hpp"
 
 std::string MsgpackPacker::getPacked()
 {

--- a/nao_lola_client/src/msgpack_parser.cpp
+++ b/nao_lola_client/src/msgpack_parser.cpp
@@ -15,6 +15,12 @@
 #include <vector>
 #include <map>
 #include <string>
+#include "msgpack/object.hpp"
+#include "msgpack/adaptor/float.hpp"
+#include "msgpack/adaptor/map.hpp"
+#include "msgpack/adaptor/string.hpp"
+#include "msgpack/adaptor/vector.hpp"
+#include "msgpack/unpack.hpp"
 #include "nao_lola_client/msgpack_parser.hpp"
 #include "nao_lola_client/lola_enums.hpp"
 #include "nao_lola_client/sensor_index_conversion.hpp"

--- a/nao_lola_client/src/nao_lola_client.cpp
+++ b/nao_lola_client/src/nao_lola_client.cpp
@@ -38,7 +38,7 @@ NaoLolaClient::NaoLolaClient(const rclcpp::NodeOptions & options)
         try {
           recvData = connection.receive();
         } catch (const std::runtime_error & e) {
-          RCLCPP_ERROR_SKIPFIRST_THROTTLE(get_logger(), *get_clock(), 1000, e.what());
+          RCLCPP_ERROR_STREAM_SKIPFIRST_THROTTLE(get_logger(), *get_clock(), 1000, e.what());
           continue;
         }
 

--- a/nao_lola_client/test/test_msgpack_packer.cpp
+++ b/nao_lola_client/test/test_msgpack_packer.cpp
@@ -17,7 +17,14 @@
 #include <vector>
 #include <map>
 #include <memory>
-#include "msgpack.hpp"
+#include "msgpack/object.hpp"
+#include "msgpack/adaptor/bool.hpp"
+#include "msgpack/adaptor/float.hpp"
+#include "msgpack/adaptor/map.hpp"
+#include "msgpack/adaptor/string.hpp"
+#include "msgpack/adaptor/vector.hpp"
+#include "msgpack/adaptor/vector_bool.hpp"
+#include "msgpack/unpack.hpp"
 #include "nao_lola_client/msgpack_packer.hpp"
 #include "nao_lola_command_msgs/msg/joint_positions.hpp"
 #include "nao_lola_command_msgs/msg/joint_stiffnesses.hpp"

--- a/nao_lola_client/test/test_msgpack_parser.cpp
+++ b/nao_lola_client/test/test_msgpack_parser.cpp
@@ -17,6 +17,14 @@
 #include <map>
 #include <string>
 #include <memory>
+#include "msgpack/object.hpp"
+#include "msgpack/adaptor/float.hpp"
+#include "msgpack/adaptor/int.hpp"
+#include "msgpack/adaptor/vector.hpp"
+#include "msgpack/adaptor/map.hpp"
+#include "msgpack/adaptor/string.hpp"
+#include "msgpack/pack.hpp"
+#include "msgpack/zone.hpp"
 #include "nao_lola_client/msgpack_parser.hpp"
 #include "nao_lola_sensor_msgs/msg/joint_indexes.hpp"
 


### PR DESCRIPTION
Resolves: #33

Attempt at speeding up compile speeds. Changes so far optimize header includes from rclcpp and msgpack that were taking long.

The node-creation process done by rclcpp componets is also slow, as it includes "rclcpp/rclcpp.hpp". It should only need to include the necessary header files.

The slowest part by far when compiling nao_lola_client is the "create_subscription" calls that happen in nao_lola_client, and is discussed in https://github.com/ros2/rclcpp/issues/1949