### PR TITLE
Fix rolling CI

### DIFF
--- a/.github/workflows/build_and_test_rolling.yaml
+++ b/.github/workflows/build_and_test_rolling.yaml
@@ -22,7 +22,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:jammy
+      image: ubuntu:noble
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/build_and_test_rolling.yaml
+++ b/.github/workflows/build_and_test_rolling.yaml
@@ -26,9 +26,9 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: ros-tooling/setup-ros@v0.7
+      - uses: ros-tooling/setup-ros@master
         with:
           use-ros2-testing: true
-      - uses: ros-tooling/action-ros-ci@v0.3
+      - uses: ros-tooling/action-ros-ci@master
         with:
           target-ros2-distro: rolling


### PR DESCRIPTION
Releases in setup-ros and action-ros-ci with ubuntu noble support have not been released yet, but they are avaiable in the master branch. Opened #45 to remember to switch back later.